### PR TITLE
Disable login form autofocus

### DIFF
--- a/templates/core/loginform.mustache
+++ b/templates/core/loginform.mustache
@@ -437,26 +437,6 @@
 </div>
 
 {{#js}}
-    document.get
-    {{^error}}
-        {{#autofocusform}}
-            require(['core_form/events'], function(FormEvent) {
-                function autoFocus() {
-                    const userNameField = document.getElementById('username');
-                    if (userNameField.value.length == 0) {
-                        userNameField.focus();
-                    } else {
-                        document.getElementById('password').focus();
-                    }
-                }
-                autoFocus();
-                window.addEventListener(FormEvent.eventTypes.fieldStructureChanged, autoFocus);
-            });
-        {{/autofocusform}}
-    {{/error}}
-    {{#error}}
-        document.getElementById('loginerrormessage').focus();
-    {{/error}}
     {{#togglepassword}}
         require(['core/togglesensitive'], function(ToggleSensitive) {
             ToggleSensitive.init("password", {{smallscreensonly}});


### PR DESCRIPTION
## Summary
- remove username autofocus script from the login form template

## Testing
- `php -l locallogin.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685a9a81e7508322b9bc937ea0c04273