### PR TITLE
Disable login form autofocus

### DIFF
--- a/scss/boost_union/post.scss
+++ b/scss/boost_union/post.scss
@@ -1524,6 +1524,14 @@ body.pagelayout-login:not(.loginbackgroundimage) #footnote {
     border-top: none;
 }
 
+/* Avoid scroll caused by the login background image text. */
+body.pagelayout-login #loginbackgroundimagetext {
+    position: fixed;
+    bottom: 0;
+    right: 0;
+    margin: 0;
+}
+
 /*---------------------------------------
  * Settings: Footer.
  --------------------------------------*/

--- a/templates/core/loginform.mustache
+++ b/templates/core/loginform.mustache
@@ -437,26 +437,6 @@
 </div>
 
 {{#js}}
-    document.get
-    {{^error}}
-        {{#autofocusform}}
-            require(['core_form/events'], function(FormEvent) {
-                function autoFocus() {
-                    const userNameField = document.getElementById('username');
-                    if (userNameField.value.length == 0) {
-                        userNameField.focus();
-                    } else {
-                        document.getElementById('password').focus();
-                    }
-                }
-                autoFocus();
-                window.addEventListener(FormEvent.eventTypes.fieldStructureChanged, autoFocus);
-            });
-        {{/autofocusform}}
-    {{/error}}
-    {{#error}}
-        document.getElementById('loginerrormessage').focus();
-    {{/error}}
     {{#togglepassword}}
         require(['core/togglesensitive'], function(ToggleSensitive) {
             ToggleSensitive.init("password", {{smallscreensonly}});

--- a/templates/theme_boost/login.mustache
+++ b/templates/theme_boost/login.mustache
@@ -62,7 +62,7 @@
         </div>
     </div>
     {{# loginbackgroundimagetext }}
-        <div class="container-fluid">
+        <div class="container-fluid position-fixed bottom-0 end-0">
             <div class="row justify-content-end mx-3 my-2" id="loginbackgroundimagetext">
                 <span class="small d-none d-md-inline text-{{loginbackgroundimagetextcolor}}">
                     {{loginbackgroundimagetext}}


### PR DESCRIPTION
## Summary
- remove username autofocus script from the login form template
- fix scroll by absolutely positioning background image text

## Testing
- `php -l locallogin.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685a9a81e7508322b9bc937ea0c04273