### PR TITLE
Fix login language menu dropdown

### DIFF
--- a/templates/core/loginform.mustache
+++ b/templates/core/loginform.mustache
@@ -15,9 +15,6 @@
     along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 }}
 
-<script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha384-1H217gwSVyLSIfaLxHbE7dRb3v4mYCKbpQvzx0cegeju1MVsGrX5xXxAvs/HgeFs" crossorigin="anonymous"></script>
-<script src="https://cdn.jsdelivr.net/npm/popper.js@1.12.9/dist/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
 <style>
     #dropdown-loginmenu.dropdown-menu.show {display:contents;}
 </style>
@@ -350,7 +347,7 @@
             <!-- AAI Login panel END --> <br/> 
     <!-- Dropdown Start -->
     <div class="dropdown onecolumn justify-content-center">
-        <button class="btn btn-secondary btn-block dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{{#str}}manuallogin, theme_boost_union{{/str}}</button>  
+        <button class="btn btn-secondary btn-block dropdown-toggle" type="button" id="dropdownMenuButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{{#str}}manuallogin, theme_boost_union{{/str}}</button>
         <div class="dropdown-menu" id="dropdown-loginmenu" aria-labelledby="dropdownMenuButton">
             <form class="login-form my-2" action="{{loginurl}}" method="post" id="login">
                 <input type="hidden" name="logintoken" value="{{logintoken}}">


### PR DESCRIPTION
## Summary
- remove external JS that conflicted with Moodle's dropdowns
- switch manual login dropdown to Bootstrap 5 attribute

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685b94d5d3108322a3ff9cf0bb0165a3