### PR TITLE
Make entire course section header clickable

### DIFF
--- a/amd/build/sectionheaderlink.min.js
+++ b/amd/build/sectionheaderlink.min.js
@@ -1,0 +1,7 @@
+/**
+ * Theme Boost Union - make course section headers clickable
+ *
+ * @module     theme_boost_union/sectionheaderlink
+ */
+define("theme_boost_union/sectionheaderlink",["jquery"],function($){return{init:function(){$(document).on("click",".course-section-header",function(e){if($(e.target).closest("a, button").length)return;var link=$(this).find(".sectionname a").get(0);link&&(e.preventDefault(),link.click())})}}});
+//# sourceMappingURL=sectionheaderlink.min.js.map

--- a/amd/build/sectionheaderlink.min.js.map
+++ b/amd/build/sectionheaderlink.min.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"sectionheaderlink.min.js","sources":["../src/sectionheaderlink.js"],"sourcesContent":null,"names":[],"mappings":""}

--- a/amd/src/sectionheaderlink.js
+++ b/amd/src/sectionheaderlink.js
@@ -1,0 +1,41 @@
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Theme Boost Union - make course section headers clickable.
+ *
+ * @module     theme_boost_union/sectionheaderlink
+ * @copyright  2025 ChatGPT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+define(['jquery'], function($) {
+    "use strict";
+
+    return {
+        init: function() {
+            $(document).on('click', '.course-section-header', function(e) {
+                if ($(e.target).closest('a, button').length) {
+                    return;
+                }
+                var link = $(this).find('.sectionname a').get(0);
+                if (link) {
+                    e.preventDefault();
+                    link.click();
+                }
+            });
+        }
+    };
+});

--- a/layout/drawers.php
+++ b/layout/drawers.php
@@ -188,6 +188,8 @@ require_once(__DIR__ . '/includes/footerbuttons.php');
 
 // Include the content for the scrollspy.
 require_once(__DIR__ . '/includes/scrollspy.php');
+// Include the content for making course section headers clickable.
+require_once(__DIR__ . '/includes/sectionheaderlink.php');
 
 // Include the template content for the footnote.
 require_once(__DIR__ . '/includes/footnote.php');

--- a/layout/includes/sectionheaderlink.php
+++ b/layout/includes/sectionheaderlink.php
@@ -1,0 +1,30 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Theme Boost Union - course section header click include.
+ *
+ * @package   theme_boost_union
+ * @copyright 2025 ChatGPT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+// Add JS to make the whole section header clickable on course pages only.
+if ($PAGE->pagelayout === 'course' && $PAGE->course->id != SITEID) {
+    $PAGE->requires->js_call_amd('theme_boost_union/sectionheaderlink', 'init');
+}


### PR DESCRIPTION
## Summary
- add new AMD module to trigger section opening when clicking on the header
- load the new module on course pages

## Testing
- `moodle-plugin-ci phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685bff89d3388322afcc385c117c83fc